### PR TITLE
Remove Hugging Face social link from homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,18 +23,20 @@ export default function HomePage() {
               socials
             </h2>
             <ul className="">
-              {socialAccounts.map((account) => (
-                <li key={account.name}>
-                  <a
-                    href={account.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs underline decoration-dotted decoration-offset-2 hover:decoration-solid"
-                  >
-                    {account.pretty}
-                  </a>
-                </li>
-              ))}
+              {socialAccounts
+                .filter((account) => account.name !== "huggingface")
+                .map((account) => (
+                  <li key={account.name}>
+                    <a
+                      href={account.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs underline decoration-dotted decoration-offset-2 hover:decoration-solid"
+                    >
+                      {account.pretty}
+                    </a>
+                  </li>
+                ))}
             </ul>
           </div>
 


### PR DESCRIPTION
Removes the Hugging Face profile link from the socials section on the main landing page.

### Changes
- Filters out the `huggingface` account when rendering social links in `app/page.tsx`.

### Notes
- The Hugging Face profile remains accessible via the terminal (`huggingface` command still works).
- No other files or dependencies were changed.

This is a minimal, targeted update to the homepage social links.